### PR TITLE
[Feature]:Added Complete Test Summary 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,10 +38,14 @@ runs:
       ${GITHUB_ACTION_PATH}/install.sh
       ${GITHUB_ACTION_PATH}/install.sh > ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt
       cat ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt
-      grep "TESTRUN SUMMARY. For testrun with id: " ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt | sed -r "s/\x1B\[[0-9;]*[mGK]//g" > ${GITHUB_WORKSPACE}/${WORKDIR}/final.out
-      grep "Total tests: " ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt | sed -r "s/\x1B\[[0-9;]*[mGK]//g" >> ${GITHUB_WORKSPACE}/${WORKDIR}/final.out
-      grep "Total test passed: " ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt | sed -r "s/\x1B\[[0-9;]*[mGK]//g" >> ${GITHUB_WORKSPACE}/${WORKDIR}/final.out
-      grep "Total test failed: " ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt | sed -r "s/\x1B\[[0-9;]*[mGK]//g" >> ${GITHUB_WORKSPACE}/${WORKDIR}/final.out
+
+      # Search for the complete testrun summary and extract total tests, total test passed, and total test failed data
+      grep -oE "COMPLETE TESTRUN SUMMARY\.\s+Total tests: [0-9]+" ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt | sed -r "s/\x1B\[[0-9;]*[mGK]//g" > ${GITHUB_WORKSPACE}/${WORKDIR}/final_total_tests.out
+      grep -oE "COMPLETE TESTRUN SUMMARY\.\s+Total test passed: [0-9]+" ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt | sed -r "s/\x1B\[[0-9;]*[mGK]//g" > ${GITHUB_WORKSPACE}/${WORKDIR}/final_total_passed.out
+      grep -oE "COMPLETE TESTRUN SUMMARY\.\s+Total test failed: [0-9]+" ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt | sed -r "s/\x1B\[[0-9;]*[mGK]//g" > ${GITHUB_WORKSPACE}/${WORKDIR}/final_total_failed.out
+
+      # Combine the results into a single file and prepare output
+      cat ${GITHUB_WORKSPACE}/${WORKDIR}/final_total_tests.out ${GITHUB_WORKSPACE}/${WORKDIR}/final_total_passed.out ${GITHUB_WORKSPACE}/${WORKDIR}/final_total_failed.out > ${GITHUB_WORKSPACE}/${WORKDIR}/final.out
       echo 'KEPLOY_REPORT<<EOF' > $GITHUB_OUTPUT
       cat ${GITHUB_WORKSPACE}/${WORKDIR}/final.out >> $GITHUB_OUTPUT
       echo 'EOF' >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixes:#1506 https://github.com/keploy/keploy/issues/1506

This pull request updates the workflow script responsible for extracting the test summary information to address the issue where only the last test-set summary was being saved and output to the pull request. 

- Modified the script to search for the complete test run summary pattern specified in the issue description.
- The pattern we are searching for is: 
`<=========================================>
  COMPLETE TESTRUN SUMMARY.
        Total tests: 6
        Total test passed: 3
        Total test failed: 3
 <=========================================>`

 As per changes made in https://github.com/keploy/keploy/pull/1326
 

### Reason for Change:
Previously, the script only searched for four specific lines, which caused issues when there were multiple test sets. By updating the script to search for the complete test run summary pattern, we ensure that all relevant test summary information is captured and outputted correctly.

### Screenshots :

![image](https://github.com/keploy/testGPT/assets/114267538/c07381f4-fd6c-4d5e-8c96-5a2d8c7304f8)
![image](https://github.com/keploy/testGPT/assets/114267538/863a2a4c-f8c5-4520-95bb-b64c385ef468)

### Note:
- Any changes to the above pattern in #1326 must be reflected into this PR for it to retain functionality.
