### PR TITLE
[bug]: the Body is empty in github/action script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,4 +88,4 @@ runs:
             repo: context.repo.repo,
             body: process.env.KEPLOY_REPORT
           })
-    shell: bash
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Keploy TestRun Report'
-description: "A action to run e2e test run"
+description: "An action to run e2e test run"
 author: Alphasians
 branding:
   icon: 'activity'
@@ -24,44 +24,57 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - name: Setup GITHUB_PATH for script
-    run: |
-      echo "${{ github.action_path }}" >> $GITHUB_PATH
-      echo "${{ inputs.working-directory }}"
-    shell: bash
-  - name: Grant permissions
-    run: chmod +x ${GITHUB_ACTION_PATH}/install.sh
-    shell: sh
-  - id: keploy-test-report
-    name: Run Script
-    run:  |
-      ${GITHUB_ACTION_PATH}/install.sh
-      ${GITHUB_ACTION_PATH}/install.sh > ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt
-      cat ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt
-      grep "TESTRUN SUMMARY. For testrun with id: " ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt | sed -r "s/\x1B\[[0-9;]*[mGK]//g" > ${GITHUB_WORKSPACE}/${WORKDIR}/final.out
-      grep "Total tests: " ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt | sed -r "s/\x1B\[[0-9;]*[mGK]//g" >> ${GITHUB_WORKSPACE}/${WORKDIR}/final.out
-      grep "Total test passed: " ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt | sed -r "s/\x1B\[[0-9;]*[mGK]//g" >> ${GITHUB_WORKSPACE}/${WORKDIR}/final.out
-      grep "Total test failed: " ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt | sed -r "s/\x1B\[[0-9;]*[mGK]//g" >> ${GITHUB_WORKSPACE}/${WORKDIR}/final.out
-      echo 'KEPLOY_REPORT<<EOF' > $GITHUB_OUTPUT
-      cat ${GITHUB_WORKSPACE}/${WORKDIR}/final.out >> $GITHUB_OUTPUT
-      echo 'EOF' >> $GITHUB_OUTPUT
-      cat $GITHUB_OUTPUT
-    shell: bash
-    env:
-      WORKDIR: ${{ inputs.working-directory }}
-      DELAY: ${{ inputs.delay }}
-      COMMAND : ${{ inputs.command }}
-      KEPLOY_PATH: ${{inputs.keploy-path}}
-  - name: Comment on PR
-    uses: actions/github-script@v6
-    env:
-      KEPLOY_REPORT: ${{ steps.keploytestreport.outputs.KEPLOY_REPORT }}
-    with:
-      github-token: ${{ github.token }}
-      script: |
-        github.rest.issues.createComment({
-          issue_number: context.issue.number,
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          body: process.env.KEPLOY_REPORT
-        })
+    - name: Setup GITHUB_PATH for script
+      run: |
+        echo "${{ github.action_path }}" >> $GITHUB_PATH
+        echo "${{ inputs.working-directory }}"
+      shell: bash
+    - name: Grant permissions
+      run: chmod +x ${GITHUB_ACTION_PATH}/install.sh
+      shell: sh
+    - id: keploy-test-report
+      name: Run Script
+      run:  |
+        ${GITHUB_ACTION_PATH}/install.sh
+        ${GITHUB_ACTION_PATH}/install.sh > ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt
+        cat ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt
+        grep "TESTRUN SUMMARY. For testrun with id: " ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt | sed -r "s/\x1B\[[0-9;]*[mGK]//g" > ${GITHUB_WORKSPACE}/${WORKDIR}/final.out
+        grep "Total tests: " ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt | sed -r "s/\x1B\[[0-9;]*[mGK]//g" >> ${GITHUB_WORKSPACE}/${WORKDIR}/final.out
+        grep "Total test passed: " ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt | sed -r "s/\x1B\[[0-9;]*[mGK]//g" >> ${GITHUB_WORKSPACE}/${WORKDIR}/final.out
+        grep "Total test failed: " ${GITHUB_WORKSPACE}/${WORKDIR}/report.txt | sed -r "s/\x1B\[[0-9;]*[mGK]//g" >> ${GITHUB_WORKSPACE}/${WORKDIR}/final.out
+        echo 'KEPLOY_REPORT<<EOF' > $GITHUB_OUTPUT
+        cat ${GITHUB_WORKSPACE}/${WORKDIR}/final.out >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
+        cat $GITHUB_OUTPUT
+      shell: bash
+      env:
+        WORKDIR: ${{ inputs.working-directory }}
+        DELAY: ${{ inputs.delay }}
+        COMMAND : ${{ inputs.command }}
+        KEPLOY_PATH: ${{inputs.keploy-path}}
+    - name: Check if report is generated
+      run: |
+        if [ -s ${GITHUB_WORKSPACE}/${WORKDIR}/final.out ]; then
+          echo "Report generated successfully."
+        else
+          echo "Error: Report not generated." >&2
+          exit 1
+        fi
+    - name: Comment on PR
+      if: success()
+      uses: actions/github-script@v6
+      env:
+        KEPLOY_REPORT: ${{ steps.keploy-test-report.outputs.KEPLOY_REPORT }}
+      with:
+        github-token: ${{ github.token }}
+        script: |
+          if (!process.env.KEPLOY_REPORT) {
+            console.error('Error: KEPLOY_REPORT not found.');
+            process.exit(1);
+          }
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: process.env.KEPLOY_REPORT
+          })


### PR DESCRIPTION
### Bug Fix: Ensure Proper Handling of Test Run Report in Workflow

Fixes: https://github.com/keploy/keploy/issues/1507

#### Description:
This PR addresses an issue in the existing GitHub Actions workflow where the test run report was not correctly captured and passed to the subsequent step for creating a comment on pull requests (PRs). The workflow was failing due to an empty `KEPLOY_REPORT`, resulting in a validation error when attempting to create a comment.

#### Changes:
- Added a new step to verify if the test run report (`final.out`) is generated successfully. If the report is empty or not generated, the workflow will fail, providing better error handling.
- Modified the "Comment on PR" step to create a comment only if the previous steps are successful. Additionally, added error handling to check if `KEPLOY_REPORT` is not empty before creating the comment.


With these changes, the workflow now correctly handles the test run report and creates a comment on PRs only when the report is successfully generated, preventing validation errors and ensuring smoother workflow execution.